### PR TITLE
Fix: Correct image paths for local assets in components

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { CheckCircle, Award, Building as FactoryBuilding, Users, User as UserHard } from 'lucide-react';
 
+import aboutImg1 from '/src/ASSETS/NARIMG_1944.JPG';
+import aboutImg2 from '/src/ASSETS/tng2image0 (2).png';
+import aboutImg3 from '/src/ASSETS/logcabinIMG_2435.jpg';
+import aboutImg4 from '/src/ASSETS/stairBB51B454-D8E1-419B-A1C1-4E9B4918F82E.png';
+
 const About = () => {
   const achievements = [
     { icon: <Award size={20} />, count: '5+', label: 'Years in Business' },
@@ -26,13 +31,13 @@ const About = () => {
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-4">
                 <img 
-                  src="/src/ASSETS/NARIMG_1944.JPG" 
+                  src={aboutImg1}
                   alt="Craftsman working with wood" 
                   className="rounded-lg object-cover h-64 w-full shadow-md"
                   loading="lazy"
                 />
                 <img 
-                  src="/src/ASSETS/tng2image0 (2).png" 
+                  src={aboutImg2}
                   alt="Woodworking detail" 
                   className="rounded-lg object-cover h-48 w-full shadow-md"
                   loading="lazy"
@@ -40,13 +45,13 @@ const About = () => {
               </div>
               <div className="mt-8 space-y-4">
                 <img 
-                  src="/src/ASSETS/logcabinIMG_2435.jpg" 
+                  src={aboutImg3}
                   alt="Cabin exterior" 
                   className="rounded-lg object-cover h-48 w-full shadow-md"
                   loading="lazy"
                 />
                 <img 
-                  src="/src/ASSETS/stairBB51B454-D8E1-419B-A1C1-4E9B4918F82E.png" 
+                  src={aboutImg4}
                   alt="Wood beam interior" 
                   className="rounded-lg object-cover h-64 w-full shadow-md"
                   loading="lazy"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { ChevronRight, Award, Shield, Clock } from 'lucide-react';
+import heroLogo from '/src/ASSETS/04A49A2A-F9DC-4BEC-B3D3-FD88BACB52E4.PNG';
 
 const Hero = () => {
   const [isVisible, setIsVisible] = useState(false);
@@ -100,7 +101,7 @@ const Hero = () => {
           >
             <div className="flex justify-center items-center">
               <img 
-                src="/src/ASSETS/04A49A2A-F9DC-4BEC-B3D3-FD88BACB52E4.PNG" 
+                src={heroLogo}
                 alt="Talaveras Framing LLC Logo" 
                 className="w-full max-w-lg h-auto object-contain filter drop-shadow-2xl"
               />

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Menu, X, ChevronDown, Phone } from 'lucide-react';
+import { Menu, X, Phone } from 'lucide-react';
 
 const Navbar = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { Home, TreePine, Ruler, Briefcase, ChevronRight } from 'lucide-react';
 
+import serviceImg1 from '/src/ASSETS/TNG97FCAB53-2F3F-48F4-9208-842039BB9743.png';
+import serviceImg2 from '/src/ASSETS/IMG_5215 (2).jpg';
+import serviceImg3 from '/src/ASSETS/cabin (3).jpg';
+import serviceImg4 from '/src/ASSETS/IMG_1931 (1).jpg';
+
 interface ServiceCardProps {
   icon: React.ReactNode;
   title: string;
@@ -49,28 +54,28 @@ const Services = () => {
       icon: <Ruler className="text-wood" size={18} />,
       title: "Custom Wood Carpentry",
       description: "Premium wood framing and carpentry services with meticulous attention to detail for custom homes, remodels, and additions.",
-      imageSrc: "/src/ASSETS/TNG97FCAB53-2F3F-48F4-9208-842039BB9743.png",
+      imageSrc: serviceImg1,
       delay: "delay-75",
     },
     {
       icon: <Home className="text-wood" size={18} />,
       title: "Custom Garages",
       description: "Stunning exposed beams, trusses, and timber accents that showcase the natural beauty of wood in your home or business.",
-      imageSrc: "/src/ASSETS/IMG_5215 (2).jpg",
+      imageSrc: serviceImg2,
       delay: "delay-150",
     },
     {
       icon: <TreePine className="text-wood" size={18} />,
       title: "Decks, Cabins & Log Houses",
       description: "Custom-designed decks, authentic cabins, and log houses built with premium materials and expert craftsmanship.",
-      imageSrc: "/src/ASSETS/cabin (3).jpg",
+      imageSrc: serviceImg3,
       delay: "delay-225",
     },
     {
       icon: <Briefcase className="text-wood" size={18} />,
       title: "Commercial & Residential Projects",
       description: "Full-service wood construction for both commercial buildings and residential homes, with personalized solutions.",
-      imageSrc: "/src/ASSETS/IMG_1931 (1).jpg",
+      imageSrc: serviceImg4,
       delay: "delay-300",
     },
   ];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,5 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  assetsInclude: ['**/*.PNG', '**/*.JPG', '**/*.jpg', '**/*.png', '**/*.svg', '**/*.gif'],
 });


### PR DESCRIPTION
- Updated Hero.tsx, Services.tsx, and About.tsx to import local images using Vite's asset handling mechanism.
- Previously, hardcoded paths like '/src/ASSETS/...' were used, which caused 404 errors in the deployed build as the 'src' directory is not served.
- Added various image file extensions to `assetsInclude` in `vite.config.ts` to ensure Vite processes these files as assets when imported with absolute-looking paths from the project root (e.g., '/src/ASSETS/...').
- Fixed a minor linting error (unused import) in Navbar.tsx.